### PR TITLE
Analytics service

### DIFF
--- a/UnityProject/Assets/Prefabs/FreeTrialScreen.prefab
+++ b/UnityProject/Assets/Prefabs/FreeTrialScreen.prefab
@@ -1908,7 +1908,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: -4572344092555324391}
         m_TargetAssemblyTypeName: SuscriptionScreen, Assembly-CSharp
         m_MethodName: Next
         m_Mode: 1
@@ -2006,6 +2006,7 @@ GameObject:
   - component: {fileID: 3997249134826694251}
   - component: {fileID: 3365714740855721517}
   - component: {fileID: 549944454334026608}
+  - component: {fileID: -4572344092555324391}
   m_Layer: 5
   m_Name: FreeTrialScreen
   m_TagString: Untagged
@@ -2073,6 +2074,19 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &-4572344092555324391
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7698206910851046161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ee769f6c2304d544fabfc36fdd182392, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _nextUI: {fileID: 774655808827421709, guid: 07cda2f0b856f4543863687d90663920, type: 3}
 --- !u!1 &7779434900627119267
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/LeadSource.prefab
+++ b/UnityProject/Assets/Prefabs/LeadSource.prefab
@@ -1764,6 +1764,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cc71ae8d9a6ba4b28a51e5a62624a256, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _toggleGroup: {fileID: 7177991482139576279}
+  _freeTrailUI: {fileID: 7698206910851046161, guid: e3f1844b4baeb044db51476a65e35503, type: 3}
+  _payWallUI: {fileID: 7187779795840710150, guid: bf91186f5fbdbc2469b8a7abd5a326a1, type: 3}
 --- !u!1 &6744431999025748272
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/PaywallScreen.prefab
+++ b/UnityProject/Assets/Prefabs/PaywallScreen.prefab
@@ -2044,7 +2044,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: -43002865399405198}
         m_TargetAssemblyTypeName: PayWallScreen, Assembly-CSharp
         m_MethodName: Next
         m_Mode: 1
@@ -2617,6 +2617,8 @@ GameObject:
   - component: {fileID: 2800209696354792647}
   - component: {fileID: 1444222433939754151}
   - component: {fileID: 1983320986227082902}
+  - component: {fileID: -3901242432451464564}
+  - component: {fileID: -43002865399405198}
   m_Layer: 5
   m_Name: PaywallScreen
   m_TagString: Untagged
@@ -2684,6 +2686,55 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &-3901242432451464564
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7187779795840710150}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 578c9ef09feaff34d80fd8f5c2f19e07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _options:
+  - button: {fileID: 4124247109437253667}
+    texts:
+    - {fileID: 2148388173182074379}
+    - {fileID: 1730765308861918655}
+    - {fileID: 5844637207206552559}
+    - {fileID: 1902414743101599788}
+    images:
+    - {fileID: 4420369068334261105}
+    - {fileID: 1393242575869811256}
+  - button: {fileID: 8659011156962071215}
+    texts:
+    - {fileID: 286666030855000462}
+    - {fileID: 336938132254423}
+    images: []
+  _defaultBackgroundColor: {r: 0.9607844, g: 0.89019614, b: 0.77647066, a: 1}
+  _defaultTextColor: {r: 0.7686275, g: 0.38823533, b: 0.26666668, a: 1}
+  _defaultImagesColor: {r: 0.77647066, g: 0.4039216, b: 0.2784314, a: 1}
+  _selectedBackgroundColor: {r: 0.40000004, g: 0.5019608, b: 0.41176474, a: 1}
+  _selectedTextColor: {r: 0.9568628, g: 0.8941177, b: 0.7803922, a: 1}
+  _selectedImagesColor: {r: 0.9490197, g: 0.8862746, b: 0.77647066, a: 1}
+--- !u!114 &-43002865399405198
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7187779795840710150}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f893b21625e9d874fa77f52f84236024, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _nextUI: {fileID: 774655808827421709, guid: 07cda2f0b856f4543863687d90663920, type: 3}
+  _tMPPriceOptionA: {fileID: 1902414743101599788}
+  _tMPPriceOptionB: {fileID: 336938132254423}
+  _optionSelectorMenu: {fileID: -3901242432451464564}
 --- !u!1 &7235488163307862097
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Bootstrapper.cs
+++ b/UnityProject/Assets/Scripts/Bootstrapper.cs
@@ -10,17 +10,36 @@ public class Bootstrapper : MonoBehaviour
     }
     public static Cohort AssignedCohort { get; private set; }
     private const string _cohortKey = "UserCohort";
+    private const string _userIDKey = "UserID";
+    public static string UserID { get; private set; }
 
     private void Awake()
     {
+        //Simulation of assinging ID to the user
+        AssingUserID();
+
         //Assign our user to a cohort of Variant A, B, or C
         AssignCohort();
-        
+
         //Binding the Local ConfigService
         ServiceLocator.Bind<IConfigService>(new LocalConfigService());
 
         //Binding the Local LocalAnalyticsService
         ServiceLocator.Bind<IAnalyticsService>(new LocalAnalyticsService()); //Future TODO: integrate Mixpanel creating a Mixpanel Service that use the IAnalyticsService
+    }
+
+    private void AssingUserID()
+    {
+        if (PlayerPrefs.HasKey(_userIDKey))
+        {
+            UserID = PlayerPrefs.GetString(_userIDKey);
+        }
+        else
+        {
+            UserID = "UnityEditorUser01";
+            PlayerPrefs.SetString(_userIDKey, UserID);
+        }
+        Debug.Log($"User ID: {UserID}");
     }
 
     private void AssignCohort()

--- a/UnityProject/Assets/Scripts/Bootstrapper.cs
+++ b/UnityProject/Assets/Scripts/Bootstrapper.cs
@@ -19,6 +19,8 @@ public class Bootstrapper : MonoBehaviour
         //Binding the Local ConfigService
         ServiceLocator.Bind<IConfigService>(new LocalConfigService());
 
+        //Binding the Local LocalAnalyticsService
+        ServiceLocator.Bind<IAnalyticsService>(new LocalAnalyticsService()); //Future TODO: integrate Mixpanel creating a Mixpanel Service that use the IAnalyticsService
     }
 
     private void AssignCohort()

--- a/UnityProject/Assets/Scripts/UI/LeadSourceScreen.cs
+++ b/UnityProject/Assets/Scripts/UI/LeadSourceScreen.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
@@ -7,16 +8,55 @@ public class LeadSourceScreen : UIScreenBase
 {
     private ToggleGroup _toggleGroup;
     private Toggle _activeToggle;
+    private int _timesToggleChanged = 0;
+
+    [SerializeField] GameObject _freeTrailUI;
+    [SerializeField] GameObject _payWallUI;
+    IAnalyticsService analyticsService = ServiceLocator.Get<IAnalyticsService>();
 
     private void Awake()
     {
         _toggleGroup = GetComponentInChildren<ToggleGroup>();
+        analyticsService.Screen(this, null);
     }
 
     public override void Next()
     {
-        //TODO: Based on user's cohort, load the appropriate UI
-        //TODO: Gather Analytics
+
+        //Gather Analytics
+
+        if (!_activeToggle)
+        {
+            _activeToggle = _toggleGroup.GetFirstActiveToggle();
+        }
+
+        analyticsService.Track("LeadSourceSelected", new Dictionary<string, object>
+        {
+            { "currentScreen", ScreenName},
+            { "toggleSelected", _activeToggle.GetComponentInChildren<TMP_Text>().text},
+            { "timesToggleChanged",_timesToggleChanged}
+        });
+
+        //Based on user's cohort, load the appropriate UI
+
+        var configService = ServiceLocator.Get<IConfigService>();
+        var variantConfig = configService.GetValue<Dictionary<string, object>>(Bootstrapper.AssignedCohort.ToString(), null);
+        SuscriptionScreen newUIScreen;
+        switch (Bootstrapper.AssignedCohort)
+        {
+            case Bootstrapper.Cohort.VariantA:
+                newUIScreen = Instantiate(_freeTrailUI, transform.parent).GetComponent<SuscriptionScreen>();
+                newUIScreen.InitializeScreen(variantConfig);
+                break;
+
+            case Bootstrapper.Cohort.VariantB:
+            case Bootstrapper.Cohort.VariantC:
+                newUIScreen = Instantiate(_payWallUI, transform.parent).GetComponent<SuscriptionScreen>();
+                newUIScreen.InitializeScreen(variantConfig);
+                break;
+        }
+
+        DestroyImmediate(gameObject);
     }
 
     public void OnToggleClicked()
@@ -28,6 +68,7 @@ public class LeadSourceScreen : UIScreenBase
         if (!_activeToggle) return;
         
         var toggleText = _activeToggle.GetComponentInChildren<TMP_Text>().text;
+        _timesToggleChanged++;
         Debug.Log($"Lead Source is: {toggleText}");
     }
 }

--- a/UnityProject/Assets/Scripts/UI/OptionSelectorMenu.cs
+++ b/UnityProject/Assets/Scripts/UI/OptionSelectorMenu.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class OptionSelectorMenu : MonoBehaviour
+{
+    [Serializable]
+    public class Option
+    {
+        public Button button;
+        public List<TextMeshProUGUI> texts;
+        public List<Image> images;
+
+        public void UpdateColors(Color backgroudColor, Color textColor, Color imageColor)
+        {
+            button.image.color = backgroudColor;
+            foreach (TextMeshProUGUI text in texts)
+            {
+                text.color = textColor;
+            }
+            foreach(Image image in images)
+            {
+                image.color = imageColor;
+            }
+        }
+    }
+
+    [SerializeField]
+    private List<Option> _options = new List<Option>();
+
+    [Header("Buttons Colors")]
+    [SerializeField]
+    private Color _defaultBackgroundColor = Color.white;
+    [SerializeField]
+    private Color _defaultTextColor = Color.white;
+    [SerializeField]
+    private Color _defaultImagesColor = Color.white;
+
+    [SerializeField]
+    private Color _selectedBackgroundColor = Color.white;
+    [SerializeField]
+    private Color _selectedTextColor = Color.white;
+    [SerializeField]
+    private Color _selectedImagesColor = Color.white;
+
+
+    private int _currentSelectedIndex = -1;
+    public int CurrentOptionSelected => _currentSelectedIndex;
+
+    private int _timesUserChangedOption = 0;
+    public int TimesChangedOption => _timesUserChangedOption;
+
+    void Start()
+    {
+        for (int i = 0; i < _options.Count; i++)
+        {
+            int index = i;
+            _options[i].button.onClick.AddListener(() => SelectOption(index));
+            _options[i].UpdateColors(_defaultBackgroundColor, _defaultTextColor, _defaultImagesColor);
+
+        }
+        _timesUserChangedOption--;
+        SelectOption(0);
+    }
+
+    private void SelectOption(int newIndexSelected)
+    {
+        if (newIndexSelected == _currentSelectedIndex) return;
+
+        _timesUserChangedOption++;
+
+        int previousSelected = _currentSelectedIndex;
+        _currentSelectedIndex = newIndexSelected;
+
+        if (previousSelected > -1)
+        {
+            UpdateVisuals(previousSelected, false);
+        }
+        UpdateVisuals(_currentSelectedIndex, true);
+    }
+
+    private void UpdateVisuals(int optionIndex, bool isSelected)
+    {
+        if (isSelected)
+        {
+            _options[optionIndex].UpdateColors(_selectedBackgroundColor, _selectedTextColor, _selectedImagesColor);
+        }
+        else
+        {
+            _options[optionIndex].UpdateColors(_defaultBackgroundColor, _defaultTextColor, _defaultImagesColor);
+        }
+    }
+}

--- a/UnityProject/Assets/Scripts/UI/OptionSelectorMenu.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/OptionSelectorMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 578c9ef09feaff34d80fd8f5c2f19e07

--- a/UnityProject/Assets/Scripts/UI/PayWallScreen.cs
+++ b/UnityProject/Assets/Scripts/UI/PayWallScreen.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+public class PayWallScreen : SuscriptionScreen
+{
+    [SerializeField] private TextMeshProUGUI _tMPPriceOptionA;
+    [SerializeField] private TextMeshProUGUI _tMPPriceOptionB;
+    [SerializeField] private OptionSelectorMenu _optionSelectorMenu;
+    public override void InitializeScreen(Dictionary<string, object> newScreenConfig)
+    {
+        base.InitializeScreen(newScreenConfig);
+
+        _tMPPriceOptionA.text = $"${_screenConfiguration.GetValueOrDefault("priceOptionA", "99.99")}/year";
+        _tMPPriceOptionB.text = $"${_screenConfiguration.GetValueOrDefault("priceOptionB", "14.99")}/month";
+    }
+
+    public override void Next()
+    {
+        analyticsService.Track("startedFreeTrail", new Dictionary<string, object>
+        {
+            { "currentScreen", ScreenName},
+            {"optionAPrice", _screenConfiguration.GetValueOrDefault("priceOptionA", "99.99")},
+            { "optionBPrice", _screenConfiguration.GetValueOrDefault("priceOptionB", "14.99")},
+            {"optionSelected", _optionSelectorMenu.CurrentOptionSelected == 0 ? "Option A" : "Option B"},
+            {"timesUserChangedOption", _optionSelectorMenu.TimesChangedOption }
+        });
+
+        analyticsService.Flush();
+
+        if (_nextUI)
+        {
+            Instantiate(_nextUI, transform.parent);
+            DestroyImmediate(gameObject);
+        }
+    }
+}

--- a/UnityProject/Assets/Scripts/UI/PayWallScreen.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/PayWallScreen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f893b21625e9d874fa77f52f84236024

--- a/UnityProject/Assets/Scripts/UI/SuscriptionScreen.cs
+++ b/UnityProject/Assets/Scripts/UI/SuscriptionScreen.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SuscriptionScreen : UIScreenBase
+{
+    protected Dictionary<string, object> _screenConfiguration;
+
+    protected IAnalyticsService analyticsService = ServiceLocator.Get<IAnalyticsService>();
+
+    [SerializeField]
+    protected GameObject _nextUI;
+    
+    virtual public void InitializeScreen(Dictionary<string, object> newScreenConfig)
+    {
+        _screenConfiguration = newScreenConfig;
+        analyticsService.Screen(this, null);
+    }
+
+    public override void Next()
+    {
+        analyticsService.Track("startedFreeTrail", new Dictionary<string, object>
+        {
+            { "currentScreen", ScreenName}
+        });
+
+        analyticsService.Flush();
+
+        if (_nextUI)
+        {
+            Instantiate(_nextUI, transform.parent);
+            DestroyImmediate(gameObject);
+        }
+    }
+}

--- a/UnityProject/Assets/Scripts/UI/SuscriptionScreen.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/SuscriptionScreen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ee769f6c2304d544fabfc36fdd182392

--- a/UnityProject/Assets/Scripts/Util/LocalAnalyticsService.cs
+++ b/UnityProject/Assets/Scripts/Util/LocalAnalyticsService.cs
@@ -62,6 +62,7 @@ public class LocalAnalyticsService : IAnalyticsService
         {
             { "type", "analyticsRegister" },
             { "timestamp", DateTime.UtcNow.ToString("MM-dd-yyyy HH:mm:ss") },
+            { "userID", Bootstrapper.UserID },
             { "userCohort", Bootstrapper.AssignedCohort.ToString() }, 
             { "parameters", parameters }
         };

--- a/UnityProject/Assets/Scripts/Util/LocalAnalyticsService.cs
+++ b/UnityProject/Assets/Scripts/Util/LocalAnalyticsService.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using Newtonsoft.Json;
+
+public class LocalAnalyticsService : IAnalyticsService
+{
+    private const string _analyticsFileName = "localAnalytics.jsonl";
+    private string AnalyticsFilePath => Path.Combine(Application.persistentDataPath, _analyticsFileName);
+
+    public void CleanupService()
+    {
+        //Nothing to Cleanup for now
+    }
+
+    private void SaveAnalyticsToFile(Dictionary<string, object> data)
+    {
+        string jsonLine = JsonConvert.SerializeObject(data);
+
+        //Adding the data to the file in a new line
+        try
+        {
+            File.AppendAllText(AnalyticsFilePath, jsonLine + Environment.NewLine);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"Error writing analytics to file: {ex.Message}");
+        }
+    }
+
+    public void Flush()
+    {
+        Debug.Log("------ FLUSHING ANALYTICS FILE ------");
+
+        try
+        {
+            if (File.Exists(AnalyticsFilePath))
+            {
+                string[] lines = File.ReadAllLines(AnalyticsFilePath);
+                foreach (string line in lines)
+                {
+                    Debug.Log(line);
+                }
+            }
+            else
+            {
+                Debug.Log("No analytics file found");
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"Error reading analytics file: {ex.Message}");
+        }
+
+        Debug.Log("-------------------------------------");
+    }
+
+    public void Register(Dictionary<string, object> parameters = null)
+    {
+        var newRegister = new Dictionary<string, object>
+        {
+            { "type", "analyticsRegister" },
+            { "timestamp", DateTime.UtcNow.ToString("MM-dd-yyyy HH:mm:ss") },
+            { "userCohort", Bootstrapper.AssignedCohort.ToString() }, 
+            { "parameters", parameters }
+        };
+
+        SaveAnalyticsToFile(newRegister);
+    }
+
+    public void Screen(UIScreenBase screen, Dictionary<string, object> parameters = null)
+    {
+        if (parameters == null)
+            parameters = new Dictionary<string, object>();
+
+        parameters["ScreenDisplayed"] = screen.ScreenName;
+        Register(parameters);
+    }
+
+    public void Track(string eventName, Dictionary<string, object> parameters = null)
+    {
+        if (parameters == null)
+            parameters = new Dictionary<string, object>();
+
+        parameters["Event"] = eventName;
+        Register(parameters);
+    }
+}

--- a/UnityProject/Assets/Scripts/Util/LocalAnalyticsService.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/LocalAnalyticsService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e4c392cb23009ac488e6ed457c38c465


### PR DESCRIPTION
Implemented the Local Analytics service

The service gather the analytics from the application and writes it to a JSONL file. Each line of the file represents an analytics register.
The Flush method will print all the analytics information in the console. TODO in the future is to implement a "source of truth" to flush the information.


In the bootstrapper I simulate a user ID assigning, this should be replaced in the future with the actual user ID of the player.
_________________________________

Implemented the Analytics to the UI screens

I've created the SuscriptionScreen and PayWallScreen classes that inherit from the class UIScreenBase. This classes will gather the analytics for their respective screen and sent it to the service.

In addition, there is OptionSelectorMenu, which manage the buttons to toggle from the variantB and variantC, changing its color and register the current selected one